### PR TITLE
Fix cell underflow in case of empty msg

### DIFF
--- a/func/nft-collection.fc
+++ b/func/nft-collection.fc
@@ -35,6 +35,8 @@ _ unwrap_signed_cmd(slice signed_cmd, int public_key, int subwallet_id, int msg_
     }
     slice sender_address = cs~load_msg_addr();
 
+    throw_if(err::wrong_topup_comment, in_msg_body.slice_empty?());
+    
     int op = in_msg_body~load_uint(32);
 
     if (op == 0) { ;; regular money transfer

--- a/func/nft-collection.fc
+++ b/func/nft-collection.fc
@@ -34,10 +34,8 @@ _ unwrap_signed_cmd(slice signed_cmd, int public_key, int subwallet_id, int msg_
         return ();
     }
     slice sender_address = cs~load_msg_addr();
-
-    throw_if(err::wrong_topup_comment, in_msg_body.slice_empty?());
     
-    int op = in_msg_body~load_uint(32);
+    int op = in_msg_body.slice_empty?() ? 0 : in_msg_body~load_uint(32);
 
     if (op == 0) { ;; regular money transfer
         ;; NB: it is not possible to recover any money transferred to this account


### PR DESCRIPTION
If someone send message without a comment he will get cell underflow exception