### PR TITLE
Using ~ operator to overwrite balance value

### DIFF
--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -40,10 +40,10 @@ int send_money(int my_balance, slice address, int value) impure {
     if ((royalty_num > 0) & (royalty_denum > 0) & ~ equal_slices(royalty_address, beneficiary_address)) {
         int royalty_value = min(bid, muldiv(bid, royalty_num, royalty_denum));
         bid -= royalty_value;
-        my_balance = send_money(my_balance, royalty_address, royalty_value);
+        my_balance~send_money(royalty_address, royalty_value);
     }
 
-    my_balance = send_money(my_balance, beneficiary_address, bid);
+    my_balance~send_money(beneficiary_address, bid);
 
     return (my_balance, bidder_address, null());
 }
@@ -89,7 +89,7 @@ cell deploy_item(int my_balance, slice msg) {
         return null();
     }
     cell new_auction = process_new_bid(my_balance, bidder_address, bid, auction);
-    (my_balance, slice owner, new_auction) = maybe_end_auction(my_balance, zero_address(), new_auction, royalty_params, 0);
+    (slice owner, new_auction) = my_balance~maybe_end_auction(zero_address(), new_auction, royalty_params, 0);
     cell content = pack_item_content(nft_content, null(), token_info);
     return pack_item_state(owner, content, new_auction, royalty_params);
 
@@ -178,7 +178,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     if (~ cell_null?(auction)) {
         ;; sender do not pay for auction with its message
         my_balance -= msg_value;
-        (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, 0);
+        (owner_address, auction) = my_balance~maybe_end_auction(owner_address, auction, royalty_params, 0);
         my_balance += msg_value;
     }
 
@@ -210,7 +210,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     if (~ cell_null?(auction)) {
         throw_unless(err::forbidden_not_stake, op == 0);
         auction = process_new_bid(my_balance, sender_address, msg_value, auction);
-        (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, 0);
+        (owner_address, auction) = my_balance~maybe_end_auction(owner_address, auction, royalty_params, 0);
         cell new_state = pack_item_state(owner_address, content, auction, royalty_params);
         return save_item_data(config, new_state);
     }
@@ -259,7 +259,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     int my_balance = pair_first(get_balance());
     (cell config, cell state) = unpack_item_data();
     (slice owner_address, cell content, cell auction, cell royalty_params) = unpack_item_state(state);
-    (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, -1);
+    (owner_address, auction) = my_balance~maybe_end_auction(owner_address, auction, royalty_params, -1);
     cell new_state = pack_item_state(owner_address, content, auction, royalty_params);
     return save_item_data(config, new_state);
 }


### PR DESCRIPTION
I went through the entire smart contracts code and only found a missing op read check that was reported in pr #5.

Therefore, I decided to propose to slightly improve the work with balances using the ~ operator.