### PR TITLE
Fix ownership bug

### DIFF
--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -179,6 +179,8 @@ cell change_dns_record(cell dns, slice in_msg_body) {
         ;; sender do not pay for auction with its message
         my_balance -= msg_value;
         (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, 0);
+        cell new_state = pack_item_state(owner_address, content, auction, royalty_params);
+        save_item_data(config, new_state);
         my_balance += msg_value;
     }
 


### PR DESCRIPTION
If the auction ends on the `line 181` in the original code and we received, for example, `op::get_royalty_params` - we will not update **owner** address (but we need to update it to the **bidder** address, because we have sent `op::ownership_is_assigned` to the bidder).

**Note:** it can be done better and faster, proposed solution is addressing the issue without introducing new potentially buggy code.