### PR TITLE
common.fc: slightly optimize store_text

### DIFF
--- a/func/common.fc
+++ b/func/common.fc
@@ -91,9 +91,9 @@ _ load_text_ref(slice cs) inline {
 }
 
 builder store_text(builder b, slice text) inline {
-    int len = slice_bits(text);
-    throw_unless(err::invalid_length, mod(len, 8) == 0);
-    return b.store_uint(slice_bits(text) / 8, 8)
+    (int len, int rem) = slice_bits(text) /% 8;
+    throw_if(err::invalid_length, rem);
+    return b.store_uint(len, 8)
             .store_slice(text);
 }
 


### PR DESCRIPTION
This way it's (arguably) more readable and consumes slightly less gas:

```diff
diff --git a/a b/b
index e111ab1..d557726 100644
--- a/a
+++ b/b
@@ -1,16 +1,12 @@
   store_text PROCINLINE:<{
     //  b text
-    DUP //  b text text
-    SBITS       //  b text len
-    8 PUSHINT   //  b text len _5=8
-    MOD //  b text _6
-    0 EQINT     //  b text _8
-    201 THROWIFNOT
-    DUP //  b text text
-    SBITS       //  b text _10
-    3 RSHIFT#   //  b text _12
-    ROT //  text _12 b
-    8 STU       //  text _14
-    SWAP        //  _14 text
-    STSLICER    //  _15
+    DUP        //  b text text
+    SBITS      //  b text _4
+    8 PUSHINT  //  b text _4 _5=8
+    DIVMOD     //  b text len rem
+    201 THROWIF
+    ROT        //  text len b
+    8 STU      //  text _10
+    SWAP       //  _10 text
+    STSLICER   //  _11
   }>
```