### PR TITLE
Allow custom reference in #topup transactions

### DIFF
--- a/func/common.fc
+++ b/func/common.fc
@@ -52,6 +52,7 @@ const int err::invalid_auction_config = 223;
 
 int mod(int x, int y) asm "MOD";
 int equal_slices(slice a, slice b) asm "SDEQ";
+int is_prefix_of(slice a, slice b) asm "SDPFX";
 int builder_null?(builder b) asm "ISNULL";
 builder store_builder(builder to, builder from) asm "STBR";
 

--- a/func/nft-collection.fc
+++ b/func/nft-collection.fc
@@ -39,8 +39,8 @@ _ unwrap_signed_cmd(slice signed_cmd, int public_key, int subwallet_id, int msg_
 
     if (op == 0) { ;; regular money transfer
         ;; NB: it is not possible to recover any money transferred to this account
-        ;; so we return back all transfers except ones with comment #topup in it
-        throw_unless(err::wrong_topup_comment, equal_slices(in_msg_body, "#topup") & (in_msg_body.slice_refs() == 0));
+        ;; so we return back all transfers except ones with comment starting #topup in it
+        throw_unless(err::wrong_topup_comment, is_prefix_of("#topup", in_msg_body) & (in_msg_body.slice_refs() == 0));
 
         return ();
     }

--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -216,7 +216,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     }
 
     if (op == 0) {
-        int is_topup = equal_slices(in_msg_body, "#topup") & (in_msg_body.slice_refs() == 0);
+        int is_topup = is_prefix_of("#topup", in_msg_body) & (in_msg_body.slice_refs() == 0);
         throw_unless(err::forbidden_topup, is_topup | equal_slices(sender_address, owner_address)); ;; only owner can fill-up balance, prevent coins lost right after the auction
         ;; if owner send bid right after auction he can restore it by transfer response message
         return ();


### PR DESCRIPTION
Comparing prefix consumes same amount of GAS so this patch wont introduce additional costs.