### PR TITLE
Mishanok

### DIFF
--- a/func/common.fc
+++ b/func/common.fc
@@ -128,7 +128,7 @@ cell pack_init_int_message(slice dest, cell state_init, cell body) inline {
             .store_uint(0x18, 6) ;; 011000 tag=0, ihr_disabled=1, allow_bounces=1, bounced=1, add_none
             .store_slice(dest)
             .store_grams(0) ;; grams
-            .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+            .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
             .store_ref(state_init)
             .store_ref(body)
             .end_cell();

--- a/func/common.fc
+++ b/func/common.fc
@@ -49,6 +49,7 @@ const int err::forbidden_auction = 220;
 const int err::already_has_stakes = 221;
 const int err::auction_already_started = 222;
 const int err::invalid_auction_config = 223;
+const int err::invalid_message = 224;
 
 int mod(int x, int y) asm "MOD";
 int equal_slices(slice a, slice b) asm "SDEQ";

--- a/func/nft-collection.fc
+++ b/func/nft-collection.fc
@@ -6,6 +6,7 @@ _ unwrap_signed_cmd(slice signed_cmd, int public_key, int subwallet_id, int msg_
     int ts = now();
     throw_unless(err::not_yet_valid_signature, valid_since < ts);
     throw_unless(err::expired_signature, ts < valid_till);
+    throw_if(err::invalid_message, cmd.slice_empty?());
     return cmd;
 
 }
@@ -35,7 +36,7 @@ _ unwrap_signed_cmd(slice signed_cmd, int public_key, int subwallet_id, int msg_
     }
     slice sender_address = cs~load_msg_addr();
 
-    int op = in_msg_body~load_uint(32);
+    int op = in_msg_body.slice_empty?() ? 0 : in_msg_body~load_uint(32);
 
     if (op == 0) { ;; regular money transfer
         ;; NB: it is not possible to recover any money transferred to this account

--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -342,7 +342,7 @@ slice get_username() method_id {
     return (beneficiary_address, initial_min_bid, max_bid, min_bid_step, min_extend_time, duration);
 }
 
-(int, int, slice) royalty_params() method_id {
+(int, int, slice) get_royalty_params() method_id {
     (cell config, cell state) = unpack_item_data();
     (slice owner_address, cell content, cell auction, cell royalty_params) = unpack_item_state(state);
     (int numerator, int denomenator, slice destination) = unpack_nft_royalty_params(royalty_params);

--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -208,21 +208,6 @@ cell change_dns_record(cell dns, slice in_msg_body) {
         return save_item_data(config, new_state);
     }
 
-    if (~ cell_null?(auction)) {
-        throw_unless(err::forbidden_not_stake, op == 0);
-        auction = process_new_bid(my_balance, sender_address, msg_value, auction);
-        (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, 0);
-        cell new_state = pack_item_state(owner_address, content, auction, royalty_params);
-        return save_item_data(config, new_state);
-    }
-
-    if (op == 0) {
-        int is_topup = equal_slices(in_msg_body, "#topup") & (in_msg_body.slice_refs() == 0);
-        throw_unless(err::forbidden_topup, is_topup | equal_slices(sender_address, owner_address)); ;; only owner can fill-up balance, prevent coins lost right after the auction
-        ;; if owner send bid right after auction he can restore it by transfer response message
-        return ();
-    }
-
     if (op == op::teleitem_start_auction) {
         throw_unless(err::auction_already_started, cell_null?(auction));
         throw_unless(err::forbidden_auction, equal_slices(sender_address, owner_address));
@@ -253,6 +238,22 @@ cell change_dns_record(cell dns, slice in_msg_body) {
         send_msg(sender_address, 0, op::teleitem_ok, cur_lt(), null(), 64); ;; carry all the remaining value of the inbound message
         return save_item_data(config, new_state);
     }
+
+    if (op == 0 & ~in_msg_body.slice_empty?()) {
+        int is_topup = equal_slices(in_msg_body, "#topup") & (in_msg_body.slice_refs() == 0);
+        throw_unless(err::forbidden_topup, is_topup | equal_slices(sender_address, owner_address)); ;; only owner can fill-up balance, prevent coins lost right after the auction
+        ;; if owner send bid right after auction he can restore it by transfer response message
+        return ();
+    }
+
+    if (~ cell_null?(auction)) {
+        throw_unless(err::forbidden_not_stake, op == 0);
+        auction = process_new_bid(my_balance, sender_address, msg_value, auction);
+        (my_balance, owner_address, auction) = maybe_end_auction(my_balance, owner_address, auction, royalty_params, 0);
+        cell new_state = pack_item_state(owner_address, content, auction, royalty_params);
+        return save_item_data(config, new_state);
+    }
+
     throw(err::unknown_op);
 }
 

--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -289,7 +289,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     (cell last_bid, int min_bid, int end_time) = unpack_auction_state(auction_state);
     slice bidder_address = null();
     int bid = 0;
-    if (cell_null?(last_bid)) {
+    if (~cell_null?(last_bid)) {
         (bidder_address, bid, _) = unpack_last_bid(last_bid);
     }
     return (bidder_address, bid, end_time);

--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -161,6 +161,7 @@ cell change_dns_record(cell dns, slice in_msg_body) {
     (int index, slice collection_address) = unpack_item_config(config);
 
     if (equal_slices(collection_address, sender_address)) {
+        throw_unless(err::invalid_message, in_msg_body.slice_empty?());
         throw_unless(err::forbidden_not_deploy, op == op::teleitem_msg_deploy);
         if (cell_null?(state)) {
             cell new_state = deploy_item(my_balance, in_msg_body);


### PR DESCRIPTION
Few issue here:
1. In **nft-item.fc:get_auction_info** we should check if last_bid is NOT null
2. Minor improvement: get method should start with get, so **get_royalty_params()** instead
3. Get rid **common.fc:pack_init_int_message** regundant bit storing. Message layout could be broken.
4. We need to check if message is empty to prevent exceptions
5. In nft-item operations with next op-codes are not executed when there is active auction:

- teleitem_cancel_auction
- teleitem_start_auction
- nft_cmd_transfer
- change_dns_record

Fix: put check for the new bid in the end of **recv_internal()**.

To make the nft-item smart contract more "clear", do not process "topup" messages as a bid.
Another messages with empty message body (and optional OP = 0) will be treated as a bid. 