### PR TITLE
common.fc: micro-optimize get_top_domain_bits

### DIFF
--- a/func/common.fc
+++ b/func/common.fc
@@ -66,16 +66,13 @@ slice zero_address() asm "b{00} PUSHSLICE";
 
 ;; "ton\0test\0" -> "ton"
 int get_top_domain_bits(slice domain) inline {
-    int i = 0;
-    int need_break = 0;
-    do {
-        int char = domain~load_uint(8); ;; we do not check domain.length because it MUST contains \0 character
-        need_break = char == 0;
-        if (~ need_break) {
-            i += 8;
-        }
-    } until (need_break);
-    throw_if(201, i == 0); ;; starts with \0
+    int i = -8;
+    int char = 1;
+    while (char) {
+        i += 8;
+        char = domain~load_uint(8); ;; we do not check domain.length because it MUST contains \0 character
+    }
+    throw_unless(201, i); ;; should not start with \0
     return i;
 }
 


### PR DESCRIPTION
Another micro-optimization:
```diff
diff --git a/a b/b
index 710c0fb..943df11 100644
--- a/a
+++ b/b
@@ -1,22 +1,15 @@
   get_top_domain_bits PROCINLINE:<{
     //  domain
-    0 PUSHINT  //  domain i=0
-    UNTIL:<{
+    -8 PUSHINT //  domain i=-8
+    1 PUSHINT  //  domain i=-8 char=1
+    WHILE:<{
+    }>DO<{     //  domain i
+      8 ADDCONST       //  domain i
       SWAP     //  i domain
       8 LDU    //  i char domain
-      SWAP     //  i domain char
-      0 EQINT  //  i domain need_break
-      DUP      //  i domain need_break need_break
-      NOT      //  i domain need_break _11
-      IF:<{    //  i domain need_break
-        s0 s2 XCHG     //  need_break domain i
-        8 ADDCONST     //  need_break domain i
-        s0 s2 XCHG     //  i domain need_break
-      }>       //  i domain need_break
-      s1 s2 XCHG       //  domain i need_break
+      -ROT     //  domain i char
     }> //  domain i
     NIP        //  i
     DUP        //  i i
-    0 EQINT    //  i _16
-    201 THROWIF
+    201 THROWIFNOT
   }>
```

Perhaps it's slightly less readable now, but in absense of more Fift-level constructs to express loops, I guess that's the way...