### PR TITLE
Fix generated ownership_assigned message (prev_owner instead of new_owner)

### DIFF
--- a/func/nft-item.fc
+++ b/func/nft-item.fc
@@ -30,7 +30,7 @@ int send_money(int my_balance, slice address, int value) impure {
 
     send_msg(bidder_address, 0, op::ownership_assigned, cur_lt(),
             begin_cell()
-                    .store_slice(bidder_address)
+                    .store_slice(owner)
                     .store_int(0, 1)
                     .store_int(op::teleitem_bid_info, 32)
                     .store_grams(bid)


### PR DESCRIPTION
As per https://github.com/ton-blockchain/TEPs/blob/master/text/0062-nft-standard.md ownership_assigned should contain the address of the previous owner of NFT, not a new owner.

Also per TEP 62 "If forward_amount is equal to zero, notification message should not be sent.", so sending this message is not technically correct.